### PR TITLE
Fixes duplicate onEnter callbacks

### DIFF
--- a/ios/INVRegionMonitor.m
+++ b/ios/INVRegionMonitor.m
@@ -194,14 +194,6 @@ RCT_EXPORT_METHOD(requestAuthorization:(RCTPromiseResolveBlock)resolve
     }
 }
 
-- (void) locationManager:(CLLocationManager *)locationManager
-       didDetermineState:(CLRegionState)state
-               forRegion:(CLRegion *)region {
-    if (state == CLRegionStateInside) {
-        [self _sendRegionChangeEventWithIdentifier:region.identifier didEnter:YES didExit:NO];
-    }
-}
-
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
     RCTLogInfo(@"Auth is %d", status);
 


### PR DESCRIPTION
Removes locationManager:didDetermineState:forRegion function which was causing duplicate callbacks JS side according to Apple docs here:
https://developer.apple.com/reference/corelocation/cllocationmanagerdelegate/1423570-locationmanager fixes #1