### PR TITLE
Feature/clear regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ regionMonitor.removeCircularRegion(identifier)
 	});
 ```
 
+#### `regionMonitor#clearRegions()`
+
+Removes all monitored regions that have been previously registered. This method returns a promise which always resolves.
+
+#### Example
+
+```js
+regionMonitor.clearRegions()
+	.then(() => {
+		// All regions scheduled to be removed.
+	})
+```
+
 #### `regionMonitor#requestAuthorization()`
 
 Requests the authorization required to initiate region monitoring. This method returns a promise which resolves if the authorization is allowed (or was already allowed) or rejects if region monitoring is not possible (either denied, restricted or not supported by the hardware).

--- a/index.ios.js
+++ b/index.ios.js
@@ -5,6 +5,7 @@ const RegionMonitorEventEmitter = new NativeEventEmitter(INVRegionMonitor);
 
 export default {
 	addCircularRegion: INVRegionMonitor.addCircularRegion,
+	clearRegions: INVRegionMonitor.clearRegions,
 	removeCircularRegion: INVRegionMonitor.removeCircularRegion,
 	requestAuthorization: INVRegionMonitor.requestAuthorization,
 	onRegionChange: (callback) => {

--- a/ios/INVRegionMonitor.m
+++ b/ios/INVRegionMonitor.m
@@ -216,6 +216,17 @@ RCT_EXPORT_METHOD(addCircularRegion:(nonnull NSDictionary *)center
     [self _addCircularRegion:center radius:radius identifier:identifier];
 }
 
+RCT_EXPORT_METHOD(clearRegions:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    [locationManager.monitoredRegions enumerateObjectsUsingBlock:^(__kindof CLRegion * _Nonnull region, BOOL * _Nonnull stop) {
+        RCTLogInfo(@"Stop monitoring region %@", region.identifier);
+        [locationManager stopMonitoringForRegion:region];
+    }]
+    
+    resolve(nil);
+}
+
 RCT_EXPORT_METHOD(removeCircularRegion:(nonnull NSString *)identifier
                               resolver:(RCTPromiseResolveBlock)resolve
                               rejecter:(RCTPromiseRejectBlock)reject) {

--- a/ios/INVRegionMonitor.m
+++ b/ios/INVRegionMonitor.m
@@ -222,7 +222,7 @@ RCT_EXPORT_METHOD(clearRegions:(RCTPromiseResolveBlock)resolve
     [locationManager.monitoredRegions enumerateObjectsUsingBlock:^(__kindof CLRegion * _Nonnull region, BOOL * _Nonnull stop) {
         RCTLogInfo(@"Stop monitoring region %@", region.identifier);
         [locationManager stopMonitoringForRegion:region];
-    }]
+    }];
     
     resolve(nil);
 }


### PR DESCRIPTION
Allows clearing all the registered regions in one swift move, this is simply a helper function in-case your Javascript tracking of monitored regions gets out of sync.. For example we call this when the user logs out of our app.